### PR TITLE
chore: add format:check script and CI step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,8 @@ jobs:
 
       - run: yarn install --immutable
 
+      - run: yarn format:check
+
       - run: yarn lint
 
       - run: yarn build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,7 @@ yarn build        # Build to dist/
 yarn build:netlify  # Build to netlify/ (root) and netlify/markdown/ (sub-path)
 yarn preview      # Preview the production build locally
 yarn format       # Prettier on all files
+yarn format:check  # Prettier check (read-only — fails if any file needs reformatting)
 yarn lint         # ESLint check on src/ (no auto-fix — fails on any error)
 yarn lint:fix     # ESLint with auto-fix on src/
 ```

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build:netlify": "vite build --outDir netlify && vite build --outDir netlify/markdown",
     "dev": "vite",
     "format": "prettier --write .",
+    "format:check": "prettier --check .",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "coverage": "vitest run --coverage",


### PR DESCRIPTION
## Summary

- Add `format:check` script (`prettier --check .`) to `package.json` alongside the existing `format` script
- Add `yarn format:check` as the first step in the CI workflow, before lint

Formatting regressions were previously caught only by the Husky pre-commit hook, not by CI. This closes the gap.

## Test plan

- [ ] CI `test` job passes with the new `format:check` step

🤖 Generated with [Claude Code](https://claude.com/claude-code)