### PR TITLE
fix: replace showdown with marked/turndown, align pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-yarn prettier --check . && yarn lint && yarn tsc -b && yarn test --run
+yarn prettier --check . && yarn lint && yarn tsc -b && yarn test:run

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ A vanilla TypeScript multi-page app (Vite 8) with two pages:
 
 **Key source locations:**
 
-- `src/utils/markdown.ts` — `cleanHtml`: the sanitise-and-normalise function; the primary unit-tested logic.
+- `src/utils/markdown.ts` — `cleanHtml` (sanitize-and-normalize), `markdownToHtml` (marked + cleanHtml), `htmlToMarkdown` (turndown); the primary unit-tested logic.
 - `src/utils/music-monday.ts` — `nextMonday()` (date calculation) and `template` (post template object with `text()` method).
 - `src/scripts/index.ts` — Ace editor wiring and resize-handle logic for the Markdown Parser page.
 - `src/scripts/music-monday.ts` — Form input handling and DOM updates for the Music Monday page.
@@ -50,7 +50,7 @@ ESLint (`eslint.config.mjs`, ESLint 9 flat config) handles code quality only. Ru
 ## Key decisions
 
 - **`ace` from CDN** — Ace is not bundled; `src/types/globals.d.ts` declares a minimal global interface covering the methods actually used (`edit`, `getValue`, `setValue`, `clearSelection`, `resize`, `session.selection.on`).
-- **`src/utils/` extracted for testability** — `cleanHtml` and the music-monday logic live in `src/utils/` rather than inline in the script files so they can be unit-tested without a DOM or Ace dependency.
+- **`src/utils/` extracted for testability** — `cleanHtml`, `markdownToHtml`, `htmlToMarkdown`, and the music-monday logic live in `src/utils/` rather than inline in the script files so they can be unit-tested without a DOM or Ace dependency.
 - **`base: './'`** — Both the local `dist/` build and the two Netlify builds use relative asset paths, so the same config works when served from the domain root or the `/markdown/` sub-path.
 - **No React plugin** — This is a vanilla TypeScript app; `vite.config.ts` has no `@vitejs/plugin-react`.
 - **Multi-page input** — `vite.config.ts` uses `rollupOptions.input` with both `index.html` and `music-monday.html` as named entry points.
@@ -68,7 +68,7 @@ PR #58 merged into `main`. Branch protection applied.
 - Switched npm → Yarn 4; deleted `package-lock.json`; bumped Node to v24
 - Migrated ESLint 8 → ESLint 9 flat config; added Prettier
 - Converted JS → TypeScript; extracted `src/utils/` for testability
-- Added 23 Vitest unit tests — all passing, 100% statement/line coverage
+- Added 23 Vitest unit tests — all passing, 100% statement/line coverage (33 as of PR #62)
 - Added `.github/workflows/test.yml` (lint → build → coverage)
 - Added `CLAUDE.md`, `.github/CODEOWNERS`, updated README
 - Fixed `dayYmdHs` minute zero-padding in `nextMonday()`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ yarn coverage     # Vitest with v8 coverage report
 
 A vanilla TypeScript multi-page app (Vite 8) with two pages:
 
-- **`index.html`** — Markdown Parser: a three-panel editor (Markdown input → HTML output → rendered preview) using the [Ace editor](https://ace.c9.io/) loaded from CDN, [showdown](https://github.com/showdownjs/showdown) for Markdown→HTML conversion, and [sanitize-html](https://github.com/apostrophecms/sanitize-html) for sanitisation.
+- **`index.html`** — Markdown Parser: a three-panel editor (Markdown input → HTML output → rendered preview) using the [Ace editor](https://ace.c9.io/) loaded from CDN, [marked](https://marked.js.org/) for Markdown→HTML conversion, [turndown](https://github.com/mixmark-io/turndown) for HTML→Markdown conversion, and [sanitize-html](https://github.com/apostrophecms/sanitize-html) for sanitization.
 - **`music-monday.html`** — Music Monday Markdown Generator: a form that generates Jekyll-compatible frontmatter and post body Markdown for a recurring blog series.
 
 **Key source locations:**

--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ The post date defaults to the next Monday at 11:45; the year fields default to t
 ## Stack
 
 - Vanilla [TypeScript](https://www.typescriptlang.org/) built with [Vite](https://vitejs.dev/) 8 (multi-page)
-- [showdown](https://github.com/showdownjs/showdown) for Markdown ↔ HTML conversion
-- [sanitize-html](https://github.com/apostrophecms/sanitize-html) for HTML sanitisation
+- [marked](https://marked.js.org/) for Markdown → HTML conversion
+- [turndown](https://github.com/mixmark-io/turndown) for HTML → Markdown conversion
+- [sanitize-html](https://github.com/apostrophecms/sanitize-html) for HTML sanitization
 - [Ace editor](https://ace.c9.io/) (loaded from CDN) for the editor panels
 
 ## Development
@@ -54,7 +55,7 @@ yarn coverage   # Vitest + coverage report
 
 ## Testing
 
-Vitest. 23 unit tests covering `cleanHtml` sanitization logic and the Music Monday `nextMonday()` date calculation and `template.text()` output.
+Vitest. 33 unit tests covering `cleanHtml` sanitization, `markdownToHtml` / `htmlToMarkdown` conversion, and the Music Monday `nextMonday()` date calculation and `template.text()` output.
 
 ```bash
 yarn test       # watch mode

--- a/package.json
+++ b/package.json
@@ -25,13 +25,14 @@
   "author": "Craig McNaughton",
   "license": "ISC",
   "dependencies": {
+    "marked": "^18.0.3",
     "sanitize-html": "^2.12.1",
-    "showdown": "^2.1.0"
+    "turndown": "^7.2.4"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.1",
     "@types/sanitize-html": "^2.13.0",
-    "@types/showdown": "^2.0.6",
+    "@types/turndown": "^5.0.6",
     "@typescript-eslint/eslint-plugin": "^8.31.0",
     "@typescript-eslint/parser": "^8.31.0",
     "@vitest/coverage-v8": "^4.1.5",

--- a/src/scripts/index.ts
+++ b/src/scripts/index.ts
@@ -1,9 +1,4 @@
-import { marked } from "marked";
-import TurndownService from "turndown";
-import { cleanHtml } from "../utils/markdown";
-
-marked.use({ breaks: true, gfm: true });
-const turndown = new TurndownService();
+import { cleanHtml, markdownToHtml, htmlToMarkdown } from "../utils/markdown";
 
 const main = document.querySelector("main.grid") as HTMLElement;
 const preview = document.getElementById("preview") as HTMLElement;
@@ -35,8 +30,7 @@ markdownEditor.session.selection.on("changeCursor", () => {
 const markdownEditorChange = () => {
   if (document.activeElement?.parentElement?.id === "markdown-editor") {
     const markdownValue = markdownEditor.getValue();
-    const convertedHtml = marked.parse(markdownValue) as string;
-    const clean = cleanHtml(convertedHtml);
+    const clean = markdownToHtml(markdownValue);
     previewContent.innerHTML = clean;
     htmlEditor.setValue(clean);
     htmlEditor.clearSelection();
@@ -53,7 +47,7 @@ htmlEditor.session.selection.on("changeCursor", () => {
 const htmlEditorChange = () => {
   if (document.activeElement?.parentElement?.id === "html-editor") {
     const htmlValue = htmlEditor.getValue();
-    const convertedMarkdown = turndown.turndown(htmlValue);
+    const convertedMarkdown = htmlToMarkdown(htmlValue);
     previewContent.innerHTML = cleanHtml(htmlValue);
     markdownEditor.setValue(convertedMarkdown);
     markdownEditor.clearSelection();

--- a/src/scripts/index.ts
+++ b/src/scripts/index.ts
@@ -1,11 +1,9 @@
-import showdown from "showdown";
+import { marked } from "marked";
+import TurndownService from "turndown";
 import { cleanHtml } from "../utils/markdown";
 
-const converter = new showdown.Converter({
-  simpleLineBreaks: true,
-  strikethrough: true,
-  tables: true,
-});
+marked.use({ breaks: true, gfm: true });
+const turndown = new TurndownService();
 
 const main = document.querySelector("main.grid") as HTMLElement;
 const preview = document.getElementById("preview") as HTMLElement;
@@ -37,7 +35,7 @@ markdownEditor.session.selection.on("changeCursor", () => {
 const markdownEditorChange = () => {
   if (document.activeElement?.parentElement?.id === "markdown-editor") {
     const markdownValue = markdownEditor.getValue();
-    const convertedHtml = converter.makeHtml(markdownValue);
+    const convertedHtml = marked.parse(markdownValue) as string;
     const clean = cleanHtml(convertedHtml);
     previewContent.innerHTML = clean;
     htmlEditor.setValue(clean);
@@ -55,7 +53,7 @@ htmlEditor.session.selection.on("changeCursor", () => {
 const htmlEditorChange = () => {
   if (document.activeElement?.parentElement?.id === "html-editor") {
     const htmlValue = htmlEditor.getValue();
-    const convertedMarkdown = converter.makeMarkdown(htmlValue);
+    const convertedMarkdown = turndown.turndown(htmlValue);
     previewContent.innerHTML = cleanHtml(htmlValue);
     markdownEditor.setValue(convertedMarkdown);
     markdownEditor.clearSelection();

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -1,4 +1,9 @@
 import sanitize from "sanitize-html";
+import { marked } from "marked";
+import TurndownService from "turndown";
+
+marked.use({ breaks: true, gfm: true });
+const turndown = new TurndownService();
 
 export const cleanHtml = (html: string): string => {
   return sanitize(html, {
@@ -11,3 +16,8 @@ export const cleanHtml = (html: string): string => {
     .trim()
     .replace(/&amp;nbsp;/g, "&nbsp;");
 };
+
+export const markdownToHtml = (markdown: string): string =>
+  cleanHtml(marked.parse(markdown) as string);
+
+export const htmlToMarkdown = (html: string): string => turndown.turndown(html);

--- a/tests/markdown.test.ts
+++ b/tests/markdown.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { cleanHtml } from "../src/utils/markdown";
+import {
+  cleanHtml,
+  markdownToHtml,
+  htmlToMarkdown,
+} from "../src/utils/markdown";
 
 describe("cleanHtml", () => {
   it("passes through safe block elements unchanged", () => {
@@ -54,5 +58,53 @@ describe("cleanHtml", () => {
 
   it("handles empty string", () => {
     expect(cleanHtml("")).toBe("");
+  });
+});
+
+describe("markdownToHtml", () => {
+  it("converts a paragraph", () => {
+    expect(markdownToHtml("Hello world")).toBe("<p>Hello world</p>");
+  });
+
+  it("converts a heading", () => {
+    expect(markdownToHtml("# Hello")).toBe("<h1>Hello</h1>");
+  });
+
+  it("converts single newlines to <br> (breaks: true)", () => {
+    expect(markdownToHtml("line one\nline two")).toBe(
+      "<p>line one<br />line two</p>",
+    );
+  });
+
+  it("converts GFM strikethrough (gfm: true)", () => {
+    expect(markdownToHtml("~~deleted~~")).toBe("<p><del>deleted</del></p>");
+  });
+
+  it("sanitizes script tags in output", () => {
+    expect(markdownToHtml('<script>alert("xss")</script>')).toBe("");
+  });
+});
+
+describe("htmlToMarkdown", () => {
+  it("converts a paragraph", () => {
+    expect(htmlToMarkdown("<p>Hello world</p>")).toBe("Hello world");
+  });
+
+  it("converts a heading", () => {
+    expect(htmlToMarkdown("<h3>Hello</h3>")).toBe("### Hello");
+  });
+
+  it("converts bold", () => {
+    expect(htmlToMarkdown("<strong>bold</strong>")).toBe("**bold**");
+  });
+
+  it("converts italic", () => {
+    expect(htmlToMarkdown("<em>italic</em>")).toBe("_italic_");
+  });
+
+  it("converts a link", () => {
+    expect(htmlToMarkdown('<a href="https://example.com">link</a>')).toBe(
+      "[link](https://example.com)",
+    );
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -358,6 +358,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@mixmark-io/domino@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "@mixmark-io/domino@npm:2.2.0"
+  checksum: 10c0/aa468a15f9217d425220fe6a4b3f9416cbe8e566ee14efc191c6d5cc04fe39338b16a90bbac190f28d44e69465db5f2cf95f479c621ce38060ca6b2a3d346e9d
+  languageName: node
+  linkType: hard
+
 "@napi-rs/wasm-runtime@npm:^1.1.4":
   version: 1.1.4
   resolution: "@napi-rs/wasm-runtime@npm:1.1.4"
@@ -549,10 +556,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/showdown@npm:^2.0.6":
-  version: 2.0.6
-  resolution: "@types/showdown@npm:2.0.6"
-  checksum: 10c0/7136e47a9f0b871e74d8f17afcd99bca3d356f9fd81ee4ddb5361beb41be11d6d5705b86cf8f44796b6ca61caa5c4ff408029b772e436f6a1f9021bb73f36f95
+"@types/turndown@npm:^5.0.6":
+  version: 5.0.6
+  resolution: "@types/turndown@npm:5.0.6"
+  checksum: 10c0/cc5648c115b67ba413782fd0a8ae273ad6b87940df770ab9a5fefe0303c368704013fca2a55dd08f46a2132a747912fd47f96a83162c47fd189babf1352ac4be
   languageName: node
   linkType: hard
 
@@ -954,13 +961,6 @@ __metadata:
   version: 1.1.4
   resolution: "color-name@npm:1.1.4"
   checksum: 10c0/a1a3f914156960902f46f7f56bc62effc6c94e84b2cae157a526b1c1f74b677a47ec602bf68a61abfa2b42d15b7c5651c6dbe72a43af720bc588dff885b10f95
-  languageName: node
-  linkType: hard
-
-"commander@npm:^9.0.0":
-  version: 9.5.0
-  resolution: "commander@npm:9.5.0"
-  checksum: 10c0/5f7784fbda2aaec39e89eb46f06a999e00224b3763dc65976e05929ec486e174fe9aac2655f03ba6a5e83875bd173be5283dc19309b7c65954701c02025b3c1d
   languageName: node
   linkType: hard
 
@@ -1814,7 +1814,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:^9.25.1"
     "@types/sanitize-html": "npm:^2.13.0"
-    "@types/showdown": "npm:^2.0.6"
+    "@types/turndown": "npm:^5.0.6"
     "@typescript-eslint/eslint-plugin": "npm:^8.31.0"
     "@typescript-eslint/parser": "npm:^8.31.0"
     "@vitest/coverage-v8": "npm:^4.1.5"
@@ -1822,14 +1822,24 @@ __metadata:
     eslint-config-prettier: "npm:^10.1.8"
     husky: "npm:^9.1.7"
     jsdom: "npm:^29.1.0"
+    marked: "npm:^18.0.3"
     prettier: "npm:^3.8.3"
     sanitize-html: "npm:^2.12.1"
-    showdown: "npm:^2.1.0"
+    turndown: "npm:^7.2.4"
     typescript: "npm:^5.8.3"
     vite: "npm:^8.0.10"
     vitest: "npm:^4.1.5"
   languageName: unknown
   linkType: soft
+
+"marked@npm:^18.0.3":
+  version: 18.0.3
+  resolution: "marked@npm:18.0.3"
+  bin:
+    marked: bin/marked.js
+  checksum: 10c0/f2943a439acf17942058f8e4c51373e0f8aa88194b55625ffa22db7955b9c2752fe9bdd4a31498f667d30e5667bab2c27e3f2f56a1045f53b693f000a6199840
+  languageName: node
+  linkType: hard
 
 "mdn-data@npm:2.27.1":
   version: 2.27.1
@@ -2186,17 +2196,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"showdown@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "showdown@npm:2.1.0"
-  dependencies:
-    commander: "npm:^9.0.0"
-  bin:
-    showdown: bin/showdown.js
-  checksum: 10c0/8508e060874c42338b9ebfe884763e8042d9575185d9dd3a12f7380736732893a4738f37140add97bde0c4c87d6bad66ed0761505f310df6044ee3385e2ae349
-  languageName: node
-  linkType: hard
-
 "siginfo@npm:^2.0.0":
   version: 2.0.0
   resolution: "siginfo@npm:2.0.0"
@@ -2341,6 +2340,15 @@ __metadata:
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
   checksum: 10c0/9c4759110a19c53f992d9aae23aac5ced636e99887b51b9e61def52611732872ff7668757d4e4c61f19691e36f4da981cd9485e869b4a7408d689f6bf1f14e62
+  languageName: node
+  linkType: hard
+
+"turndown@npm:^7.2.4":
+  version: 7.2.4
+  resolution: "turndown@npm:7.2.4"
+  dependencies:
+    "@mixmark-io/domino": "npm:^2.2.0"
+  checksum: 10c0/8e66e24bc9d9cdcf720f0ee2655a61d9b9e60ebe2763e97a7a8c3f689e9154717bbea7ed48cc5e355651f34182da698c6bc5fef3028e5600c1cadb7e117376d5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What

- **Replace `showdown`** (unfixed ReDoS vulnerability, Dependabot alert #93) with [`marked`](https://marked.js.org/) for Markdown→HTML and [`turndown`](https://github.com/mixmark-io/turndown) for HTML→Markdown. Both are actively maintained with no open vulnerabilities. Options are mapped 1:1: `simpleLineBreaks`→`breaks`, `strikethrough`+`tables` are enabled by default under `gfm: true`.
- **Extract conversion utils**: move `marked` and `TurndownService` setup into `src/utils/markdown.ts` alongside `cleanHtml`; export `markdownToHtml` and `htmlToMarkdown` so the conversion pipeline is testable without the Ace editor dependency.
- **Add 10 new tests** (23 → 33): `markdownToHtml` covers paragraph, heading, line breaks, strikethrough, and XSS sanitization; `htmlToMarkdown` covers paragraph, heading, bold, italic, and link.
- **Align pre-commit hook**: `yarn test --run` → `yarn test:run` to match the `test:run` script in `package.json`.
- **Docs**: update CLAUDE.md and README to reflect the new libraries, utility functions, and test count.

## Test plan

- [ ] CI passes (format:check → lint → build → coverage)
- [ ] Dependabot alert #93 resolved after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)