### PR TITLE
feat: vertical resize handle between Markdown and HTML panels

### DIFF
--- a/src/scripts/index.ts
+++ b/src/scripts/index.ts
@@ -61,7 +61,7 @@ let previewTop: number | undefined;
 let touchDiff: number | undefined;
 let columnX: number | undefined;
 let columnTouchDiff: number | undefined;
-const HANDLE_SIZE = 4; // set in CSS
+const HANDLE_SIZE = 4; // must match --handle-size in index.css
 
 const setPreviewHeight = (e: Event) => {
   if (e.type === "mousemove") previewTop = (e as MouseEvent).clientY;

--- a/src/scripts/index.ts
+++ b/src/scripts/index.ts
@@ -1,6 +1,7 @@
 import { cleanHtml, markdownToHtml, htmlToMarkdown } from "../utils/markdown";
 
 const main = document.querySelector("main.grid") as HTMLElement;
+const markdown = document.getElementById("markdown") as HTMLElement;
 const preview = document.getElementById("preview") as HTMLElement;
 const previewHeader = preview.querySelector(".subheader") as HTMLElement;
 const previewContent = document.getElementById(
@@ -58,6 +59,8 @@ const htmlEditorChange = () => {
 // https://stackoverflow.com/questions/26233180/resize-a-div-on-border-drag-and-drop-without-adding-extra-markup/53220241
 let previewTop: number | undefined;
 let touchDiff: number | undefined;
+let columnX: number | undefined;
+let columnTouchDiff: number | undefined;
 const HANDLE_SIZE = 4; // set in CSS
 
 const setPreviewHeight = (e: Event) => {
@@ -91,6 +94,35 @@ const setPreviewHeight = (e: Event) => {
   htmlEditor.resize();
 };
 
+const setColumnWidths = (e: Event) => {
+  if (e.type === "mousemove") columnX = (e as MouseEvent).clientX;
+  if (e.type === "touchmove")
+    columnX = (e as TouchEvent).touches[0].clientX - (columnTouchDiff ?? 0);
+
+  if (columnX !== undefined) {
+    const mainRect = main.getBoundingClientRect();
+    const totalWidth = mainRect.width;
+    const newWidth = columnX - mainRect.left;
+    const minWidth = totalWidth * 0.2;
+    const maxWidth = totalWidth * 0.8;
+    const setWidth =
+      newWidth > maxWidth
+        ? maxWidth
+        : newWidth < minWidth
+          ? minWidth
+          : newWidth;
+
+    if (setWidth !== newWidth) {
+      columnX = mainRect.left + setWidth;
+    }
+
+    main.style.gridTemplateColumns = `${setWidth}px 1fr`;
+  }
+
+  markdownEditor.resize();
+  htmlEditor.resize();
+};
+
 preview.querySelector(".subheader")?.addEventListener(
   "mousedown",
   (e: Event) => {
@@ -105,6 +137,7 @@ document.addEventListener(
   "mouseup",
   () => {
     document.removeEventListener("mousemove", setPreviewHeight, false);
+    document.removeEventListener("mousemove", setColumnWidths, false);
   },
   false,
 );
@@ -124,8 +157,54 @@ document.addEventListener(
   "touchend",
   () => {
     document.removeEventListener("touchmove", setPreviewHeight, false);
+    document.removeEventListener("touchmove", setColumnWidths, false);
+  },
+  false,
+);
+
+markdown.addEventListener(
+  "mousedown",
+  (e: Event) => {
+    const numAreas =
+      getComputedStyle(main).gridTemplateAreas.split('" ').length;
+    if (
+      numAreas === 2 &&
+      (e as MouseEvent).clientX >=
+        markdown.getBoundingClientRect().right - HANDLE_SIZE
+    ) {
+      document.addEventListener("mousemove", setColumnWidths, false);
+    }
+  },
+  false,
+);
+
+markdown.addEventListener(
+  "touchstart",
+  (e: Event) => {
+    const numAreas =
+      getComputedStyle(main).gridTemplateAreas.split('" ').length;
+    if (numAreas !== 2) return;
+    const touch = (e as TouchEvent).touches[0];
+    const markdownRect = markdown.getBoundingClientRect();
+    if (touch.clientX >= markdownRect.right - HANDLE_SIZE) {
+      columnTouchDiff = touch.clientX - markdownRect.right;
+      document.addEventListener("touchmove", setColumnWidths, false);
+    }
   },
   false,
 );
 
 window.addEventListener("resize", setPreviewHeight, false);
+
+window.addEventListener(
+  "resize",
+  () => {
+    const numAreas =
+      getComputedStyle(main).gridTemplateAreas.split('" ').length;
+    if (numAreas !== 2) {
+      main.style.gridTemplateColumns = "";
+      columnX = undefined;
+    }
+  },
+  false,
+);

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -121,6 +121,7 @@ button:focus {
 #markdown {
   border-right: 1px solid #dfdfdf;
   grid-area: markdown;
+  position: relative;
 }
 
 #html {
@@ -145,7 +146,7 @@ button:focus {
   content: "";
   cursor: ns-resize;
   height: 4px;
-  /* resize handle size, used in index.js */
+  /* resize handle size, used in index.ts */
   margin-left: -1rem;
   /* reset .subheader padding */
   position: absolute;
@@ -258,6 +259,23 @@ button:focus {
 
   #preview {
     max-height: 80vh;
+  }
+
+  #markdown::after {
+    background-color: rgba(223, 223, 223, 0.2);
+    content: "";
+    cursor: ew-resize;
+    height: 100%;
+    position: absolute;
+    right: 0;
+    top: 0;
+    /* resize handle size, used in index.ts */
+    width: 4px;
+    z-index: 10;
+  }
+
+  #markdown:hover::after {
+    background-color: rgba(223, 223, 223, 0.8);
   }
 }
 

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -14,9 +14,22 @@ html {
   padding: 0;
 }
 
+:root {
+  --text-color: #222;
+  --brand-color: #005b99;
+  --header-bg: #ebebef;
+  --header-border: #c3c3c7;
+  --header-text: #4a4a4e;
+  --bg-subtle: #f8f8f8;
+  --border-color: #dfdfdf;
+  --handle-bg: rgba(223, 223, 223, 0.2);
+  --handle-bg-hover: rgba(223, 223, 223, 0.8);
+  --handle-size: 4px;
+}
+
 /* https://meta.stackexchange.com/questions/364048/we-are-switching-to-system-fonts-on-may-10-2021 */
 body {
-  color: #222;
+  color: var(--text-color);
   font-family:
     system-ui,
     -apple-system,
@@ -41,7 +54,7 @@ button {
   background-color: transparent;
   border: none;
   border-radius: 0.25em;
-  color: #005b99;
+  color: var(--brand-color);
   cursor: pointer;
   display: inline-block;
   font: inherit;
@@ -61,16 +74,16 @@ button:focus {
 }
 
 .header {
-  background-color: #ebebef;
-  border-bottom: 1px solid #c3c3c7;
-  color: #4a4a4e;
+  background-color: var(--header-bg);
+  border-bottom: 1px solid var(--header-border);
+  color: var(--header-text);
   padding: 0.5rem 1rem;
 }
 
 .subheader {
   margin-bottom: 0;
   padding: 0 1rem;
-  border-bottom: 1px solid #f8f8f8;
+  border-bottom: 1px solid var(--bg-subtle);
 }
 
 .header h1,
@@ -80,7 +93,7 @@ button:focus {
 }
 
 .brand > a {
-  color: #4a4a4e;
+  color: var(--header-text);
   text-decoration: none;
 }
 
@@ -93,7 +106,7 @@ button:focus {
 }
 
 .brand svg .np__txt {
-  fill: #005b99;
+  fill: var(--brand-color);
 }
 
 .grid {
@@ -115,11 +128,11 @@ button:focus {
 
 #markdown,
 #html {
-  border-bottom: 1px solid #dfdfdf;
+  border-bottom: 1px solid var(--border-color);
 }
 
 #markdown {
-  border-right: 1px solid #dfdfdf;
+  border-right: 1px solid var(--border-color);
   grid-area: markdown;
   position: relative;
 }
@@ -141,12 +154,11 @@ button:focus {
 }
 
 #preview > .subheader::before {
-  background-color: rgba(223, 223, 223, 0.2);
+  background-color: var(--handle-bg);
   top: 0;
   content: "";
   cursor: ns-resize;
-  height: 4px;
-  /* resize handle size, used in index.ts */
+  height: var(--handle-size);
   margin-left: -1rem;
   /* reset .subheader padding */
   position: absolute;
@@ -155,7 +167,7 @@ button:focus {
 }
 
 #preview > .subheader:hover::before {
-  background-color: rgba(223, 223, 223, 0.8);
+  background-color: var(--handle-bg-hover);
 }
 
 #preview-content {
@@ -204,7 +216,7 @@ button:focus {
 }
 
 #preview-content table tbody tr:nth-child(2n) {
-  background-color: #f8f8f8;
+  background-color: var(--bg-subtle);
 }
 
 #preview-content ol,
@@ -213,7 +225,7 @@ button:focus {
 }
 
 #preview-content blockquote {
-  border-left: 1px solid #222;
+  border-left: 1px solid var(--text-color);
   padding-left: 0.5rem;
 }
 
@@ -227,13 +239,13 @@ button:focus {
 }
 
 #preview-content pre {
-  background-color: #f8f8f8;
+  background-color: var(--bg-subtle);
   padding: 0.5rem;
   width: 100%;
 }
 
 #preview-content pre code {
-  color: #222;
+  color: var(--text-color);
   font-size: 0.875rem;
 }
 
@@ -262,20 +274,19 @@ button:focus {
   }
 
   #markdown::after {
-    background-color: rgba(223, 223, 223, 0.2);
+    background-color: var(--handle-bg);
     content: "";
     cursor: ew-resize;
     height: 100%;
     position: absolute;
     right: 0;
     top: 0;
-    /* resize handle size, used in index.ts */
-    width: 4px;
+    width: var(--handle-size);
     z-index: 10;
   }
 
   #markdown:hover::after {
-    background-color: rgba(223, 223, 223, 0.8);
+    background-color: var(--handle-bg-hover);
   }
 }
 


### PR DESCRIPTION
## What

- **Vertical resize handle** — a 4 px `ew-resize` drag zone on the right border of the Markdown panel (desktop layout only, ≥ 48 rem). Mirrors the existing `ns-resize` handle on the Preview panel: same visual language, same event model, 20 %/80 % column-width clamps. On window resize back to mobile the inline `gridTemplateColumns` is cleared so the stacked layout is unaffected.
- **CSS custom properties** — adds a `:root` block with 10 design tokens (`--handle-size`, `--handle-bg`, `--handle-bg-hover`, `--border-color`, `--text-color`, `--bg-subtle`, `--brand-color`, `--header-text`, `--header-bg`, `--header-border`) and replaces every repeated literal value throughout `index.css`. Both resize handles now share the same three handle variables, removing the need for cross-file comments.

## Test plan

- [ ] On desktop (≥ 768 px): hover the right border of the Markdown panel — handle highlights
- [ ] Drag the handle left/right — columns resize, both Ace editors follow
- [ ] Drag to the 20 % and 80 % limits — movement stops at the clamp
- [ ] Resize window to mobile width — panels revert to stacked equal-height layout
- [ ] Preview panel vertical resize still works as before
- [ ] CI passes (format:check → lint → build → coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)