### PR TITLE
fix: upgrade sanitize-html and block xmp/plaintext raw-text XSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "license": "ISC",
   "dependencies": {
     "marked": "^18.0.3",
-    "sanitize-html": "^2.12.1",
+    "sanitize-html": "^2.17.4",
     "turndown": "^7.2.4"
   },
   "devDependencies": {

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -12,6 +12,19 @@ export const cleanHtml = (html: string): string => {
       { "*": ["class", "style"] },
       sanitize.defaults.allowedAttributes,
     ),
+    // xmp and plaintext are raw-text elements whose content is passed through
+    // unescaped by sanitize-html, enabling XSS bypass (CVE/Dependabot #94).
+    // Adding them here causes the entire tag and its contents to be dropped.
+    // Defaults are: style, script, textarea, option, noscript.
+    nonTextTags: [
+      "style",
+      "script",
+      "textarea",
+      "option",
+      "noscript",
+      "xmp",
+      "plaintext",
+    ],
   })
     .trim()
     .replace(/&amp;nbsp;/g, "&nbsp;");

--- a/tests/markdown.test.ts
+++ b/tests/markdown.test.ts
@@ -59,6 +59,16 @@ describe("cleanHtml", () => {
   it("handles empty string", () => {
     expect(cleanHtml("")).toBe("");
   });
+
+  it("drops xmp tag and its contents entirely", () => {
+    expect(cleanHtml("<xmp><script>alert(1)</script></xmp>")).toBe("");
+  });
+
+  it("drops plaintext tag and its contents entirely", () => {
+    expect(cleanHtml("<plaintext><script>alert(1)</script></plaintext>")).toBe(
+      "",
+    );
+  });
 });
 
 describe("markdownToHtml", () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1009,6 +1009,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dayjs@npm:^1.11.7":
+  version: 1.11.20
+  resolution: "dayjs@npm:1.11.20"
+  checksum: 10c0/8af525e2aa100c8db9923d706c42b2b2d30579faf89456619413a5c10916efc92c2b166e193c27c02eb3174b30aa440ee1e7b72b0a2876b3da651d204db848a0
+  languageName: node
+  linkType: hard
+
 "debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.4.3":
   version: 4.4.3
   resolution: "debug@npm:4.4.3"
@@ -1626,6 +1633,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"launder@npm:^1.7.1":
+  version: 1.7.1
+  resolution: "launder@npm:1.7.1"
+  dependencies:
+    dayjs: "npm:^1.11.7"
+  checksum: 10c0/c4884c08cc5a1a19cbec840aac7fa97db4928c25fc99ea2981a0482df3ebdbf1cf6605226a3c968e3281025126ff10055686e81f428ecc0e8f8666ca05bae8cc
+  languageName: node
+  linkType: hard
+
 "levn@npm:^0.4.1":
   version: 0.4.1
   resolution: "levn@npm:0.4.1"
@@ -1824,7 +1840,7 @@ __metadata:
     jsdom: "npm:^29.1.0"
     marked: "npm:^18.0.3"
     prettier: "npm:^3.8.3"
-    sanitize-html: "npm:^2.12.1"
+    sanitize-html: "npm:^2.17.4"
     turndown: "npm:^7.2.4"
     typescript: "npm:^5.8.3"
     vite: "npm:^8.0.10"
@@ -2148,17 +2164,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sanitize-html@npm:^2.12.1":
-  version: 2.17.3
-  resolution: "sanitize-html@npm:2.17.3"
+"sanitize-html@npm:^2.17.4":
+  version: 2.17.4
+  resolution: "sanitize-html@npm:2.17.4"
   dependencies:
     deepmerge: "npm:^4.2.2"
     escape-string-regexp: "npm:^4.0.0"
     htmlparser2: "npm:^10.1.0"
     is-plain-object: "npm:^5.0.0"
+    launder: "npm:^1.7.1"
     parse-srcset: "npm:^1.0.2"
     postcss: "npm:^8.3.11"
-  checksum: 10c0/8afa59bed125b38bf4b437f9b5a3289a4307f42d720e45105de5a0b3d665be70e27d1722d223121993be2e54a2b99304cd9c54317fb2d251fd7f4abf06b68d27
+  checksum: 10c0/5c352376a44bf8a70644f6d4421684000a982f6bda59beac051693d8fc08acbe48dc6358f5c8eb8ae4a815746260167926747a858e6a6e2daf01ccfb775100dd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Upgrades `sanitize-html` from `2.17.3` → `2.17.4` (Dependabot alert #94, CVSS 9.3)
- Adds `xmp` and `plaintext` to `nonTextTags` in `cleanHtml` as defense-in-depth — both are raw-text elements that `htmlparser2` does not re-parse on input, so their contents were previously passed through unescaped, enabling a sanitizer bypass / stored XSS

## Details

`sanitize-html`'s default `disallowedTagsMode: 'discard'` strips the tag but appends the raw inner text unescaped for `xmp` and similar raw-text elements. Since `htmlparser2` treats `<xmp>` content as literal text on the way in, `<xmp><script>alert(1)</script></xmp>` arrives as plain text — but is emitted as live `<script>alert(1)</script>` on the way out. Adding these tags to `nonTextTags` causes the entire element and its contents to be dropped.

## Test plan

- [ ] All 33 existing unit tests pass (`yarn test:run`)
- [ ] `yarn lint`, `yarn format:check`, `yarn tsc -b` all clean
- [ ] Pre-commit hook passes on commit