### PR TITLE
docs: link open TODOs to GitHub Project board

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,4 @@ PR #58 merged into `main`. Branch protection applied.
 ### Known follow-up items (non-blocking)
 
 - Use American English in any future source comments (`sanitize` / `sanitization`, not `sanitise`)
-- **CSS review** — header fonts appear inconsistent with AlbertCSS; app does not load AlbertCSS (no `<link>` in `index.html`) — needs investigation before changes
-- **`new/` folder** at repo root — untracked leftover from pre-Vite era (contains only `node_modules`); safe to delete
-- **`user-select: none` during drag** — neither resize handle sets it; text in Ace editors may select while dragging (low priority)
+- Remaining items (CSS/AlbertCSS review, leftover `new/` folder, drag `user-select`, GitHub Actions bump, axe tooling, Playwright E2E) tracked as issues in the [markdown GitHub Project](https://github.com/users/craigmcn/projects/6)


### PR DESCRIPTION
Replaces inline TODO lists in CLAUDE.md with a pointer to this repo's new GitHub Project (part of a cross-repo migration of all open TODOs from active_projects.md / CLAUDE.md files into per-repo GitHub Projects).

## Test plan
- [x] Docs-only change; no code affected
- [x] Pre-commit hook (format/lint/test) passed locally before push