### PR TITLE
ci: bump GitHub Actions to current majors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,15 +10,15 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version-file: .nvmrc
 
       - run: corepack enable
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version-file: .nvmrc
           cache: yarn


### PR DESCRIPTION
## Summary
- Bumps `actions/checkout` v4 -> v7 and `actions/setup-node` v4 -> v7 in `.github/workflows/test.yml`

Closes #71

## Test plan
- [x] CI runs on this PR (format:check, lint, build, coverage)