### PR TITLE
chore: switch AlbertCSS CDN link to canonical URL

### DIFF
--- a/music-monday.html
+++ b/music-monday.html
@@ -48,7 +48,7 @@
 
     <link
       rel="stylesheet"
-      href="https://www.craigmcn.com/albertcss/css/albert.min.css"
+      href="https://albertcss.craigmcn.com/css/albert.min.css"
     />
 
     <style>


### PR DESCRIPTION
## Summary
- `music-monday.html` now loads AlbertCSS from `https://albertcss.craigmcn.com/css/albert.min.css` instead of the backward-compat `https://www.craigmcn.com/albertcss/css/albert.min.css`

Closes #78

## Test plan
- [x] CI runs on this PR
- [x] Verified `music-monday.html` renders identically (same unversioned/latest stylesheet, just a new canonical host)