### PR TITLE
fix: disable text selection while dragging resize handles

### DIFF
--- a/src/scripts/index.ts
+++ b/src/scripts/index.ts
@@ -123,10 +123,19 @@ const setColumnWidths = (e: Event) => {
   htmlEditor.resize();
 };
 
+const startDragging = () => {
+  document.body.style.userSelect = "none";
+};
+
+const stopDragging = () => {
+  document.body.style.userSelect = "";
+};
+
 preview.querySelector(".subheader")?.addEventListener(
   "mousedown",
   (e: Event) => {
     if ((e as MouseEvent).offsetY <= HANDLE_SIZE) {
+      startDragging();
       document.addEventListener("mousemove", setPreviewHeight, false);
     }
   },
@@ -136,6 +145,7 @@ preview.querySelector(".subheader")?.addEventListener(
 document.addEventListener(
   "mouseup",
   () => {
+    stopDragging();
     document.removeEventListener("mousemove", setPreviewHeight, false);
     document.removeEventListener("mousemove", setColumnWidths, false);
   },
@@ -148,6 +158,7 @@ preview.querySelector(".subheader")?.addEventListener(
     touchDiff =
       (e as TouchEvent).touches[0].clientY -
       previewHeader.getBoundingClientRect().top;
+    startDragging();
     document.addEventListener("touchmove", setPreviewHeight, false);
   },
   false,
@@ -156,6 +167,7 @@ preview.querySelector(".subheader")?.addEventListener(
 document.addEventListener(
   "touchend",
   () => {
+    stopDragging();
     document.removeEventListener("touchmove", setPreviewHeight, false);
     document.removeEventListener("touchmove", setColumnWidths, false);
   },
@@ -172,6 +184,7 @@ markdown.addEventListener(
       (e as MouseEvent).clientX >=
         markdown.getBoundingClientRect().right - HANDLE_SIZE
     ) {
+      startDragging();
       document.addEventListener("mousemove", setColumnWidths, false);
     }
   },
@@ -188,6 +201,7 @@ markdown.addEventListener(
     const markdownRect = markdown.getBoundingClientRect();
     if (touch.clientX >= markdownRect.right - HANDLE_SIZE) {
       columnTouchDiff = touch.clientX - markdownRect.right;
+      startDragging();
       document.addEventListener("touchmove", setColumnWidths, false);
     }
   },

--- a/src/scripts/index.ts
+++ b/src/scripts/index.ts
@@ -129,6 +129,10 @@ const startDragging = () => {
 
 const stopDragging = () => {
   document.body.style.userSelect = "";
+  document.removeEventListener("mousemove", setPreviewHeight, false);
+  document.removeEventListener("mousemove", setColumnWidths, false);
+  document.removeEventListener("touchmove", setPreviewHeight, false);
+  document.removeEventListener("touchmove", setColumnWidths, false);
 };
 
 preview.querySelector(".subheader")?.addEventListener(
@@ -142,15 +146,8 @@ preview.querySelector(".subheader")?.addEventListener(
   false,
 );
 
-document.addEventListener(
-  "mouseup",
-  () => {
-    stopDragging();
-    document.removeEventListener("mousemove", setPreviewHeight, false);
-    document.removeEventListener("mousemove", setColumnWidths, false);
-  },
-  false,
-);
+document.addEventListener("mouseup", stopDragging, false);
+window.addEventListener("blur", stopDragging, false);
 
 preview.querySelector(".subheader")?.addEventListener(
   "touchstart",
@@ -164,15 +161,8 @@ preview.querySelector(".subheader")?.addEventListener(
   false,
 );
 
-document.addEventListener(
-  "touchend",
-  () => {
-    stopDragging();
-    document.removeEventListener("touchmove", setPreviewHeight, false);
-    document.removeEventListener("touchmove", setColumnWidths, false);
-  },
-  false,
-);
+document.addEventListener("touchend", stopDragging, false);
+document.addEventListener("touchcancel", stopDragging, false);
 
 markdown.addEventListener(
   "mousedown",


### PR DESCRIPTION
## Summary
- Dragging the vertical (preview height) or horizontal (column width) resize handles could select surrounding page text if the cursor drifted off the thin handle mid-drag
- Toggles `user-select: none` on `document.body` for the duration of a drag (mouse and touch), restoring it on release

Closes #76

## Test plan
- [x] `yarn lint`, `yarn format:check`, `yarn test:run` pass
- [x] CI runs on this PR