### PR TITLE
fix: load AlbertCSS in index.html for consistent header font

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,11 +62,10 @@
   <body id="top">
     <header id="header" class="header">
       <div class="brand">
-        <a class="flex" href="/">
+        <a href="/">
           <svg
             xmlns="http://www.w3.org/2000/svg"
             viewBox="0 0 512 512"
-            class="mr-2"
             width="40"
           >
             <rect class="np__bg" width="512" height="512" rx="51.2"></rect>
@@ -79,10 +78,10 @@
         </a>
       </div>
 
-      <h1 class="ml-auto">Markdown Parser</h1>
+      <h1>Markdown Parser</h1>
     </header>
 
-    <main class="grid">
+    <main class="app-grid">
       <section id="markdown">
         <header class="subheader">
           <h2>Markdown</h2>

--- a/index.html
+++ b/index.html
@@ -52,6 +52,10 @@
     <meta name="msapplication-TileColor" content="#ffffff" />
     <meta name="theme-color" content="#005b99" />
 
+    <link
+      rel="stylesheet"
+      href="https://albertcss.craigmcn.com/css/albert.min.css"
+    />
     <link rel="stylesheet" href="src/styles/index.css" />
   </head>
 

--- a/src/scripts/index.ts
+++ b/src/scripts/index.ts
@@ -1,6 +1,6 @@
 import { cleanHtml, markdownToHtml, htmlToMarkdown } from "../utils/markdown";
 
-const main = document.querySelector("main.grid") as HTMLElement;
+const main = document.querySelector("main.app-grid") as HTMLElement;
 const markdown = document.getElementById("markdown") as HTMLElement;
 const preview = document.getElementById("preview") as HTMLElement;
 const previewHeader = preview.querySelector(".subheader") as HTMLElement;

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,118 +1,20 @@
-html {
-  box-sizing: border-box;
-  overflow-x: hidden;
-}
-
-*,
-*::before,
-*::after {
-  box-sizing: inherit;
-}
-
-* {
-  margin: 0;
-  padding: 0;
-}
-
 :root {
-  --text-color: #222;
-  --brand-color: #005b99;
-  --header-bg: #ebebef;
-  --header-border: #c3c3c7;
-  --header-text: #4a4a4e;
-  --bg-subtle: #f8f8f8;
-  --border-color: #dfdfdf;
   --handle-bg: rgba(223, 223, 223, 0.2);
   --handle-bg-hover: rgba(223, 223, 223, 0.8);
   --handle-size: 4px;
 }
 
-/* https://meta.stackexchange.com/questions/364048/we-are-switching-to-system-fonts-on-may-10-2021 */
 body {
-  color: var(--text-color);
-  font-family:
-    system-ui,
-    -apple-system,
-    BlinkMacSystemFont,
-    "Segoe UI",
-    Ubuntu,
-    Roboto,
-    "Noto Sans",
-    "Droid Sans",
-    sans-serif;
   font-size: 90%;
-}
-
-h2 {
-  font-weight: 600;
-  margin-top: 0.67em;
-  margin-bottom: 0.67em;
-}
-
-button {
-  background: none;
-  background-color: transparent;
-  border: none;
-  border-radius: 0.25em;
-  color: var(--brand-color);
-  cursor: pointer;
-  display: inline-block;
-  font: inherit;
-  font-size: 0.9em;
-  outline: none;
-  transition: all 0.15s ease-in-out;
-}
-
-button:focus,
-button:hover,
-button:active {
-  box-shadow: none;
-}
-
-button:focus {
-  box-shadow: 0 0 0 0.2rem rgb(0 91 153 / 50%);
-}
-
-.header {
-  /* overrides AlbertCSS's grid-based .header layout, which this app's
-     header markup (no grid-area-assigned children) doesn't match */
-  display: block;
-  background-color: var(--header-bg);
-  border-bottom: 1px solid var(--header-border);
-  color: var(--header-text);
-  padding: 0.5rem 1rem;
 }
 
 .subheader {
   margin-bottom: 0;
   padding: 0 1rem;
-  border-bottom: 1px solid var(--bg-subtle);
+  border-bottom: 1px solid var(--silver);
 }
 
-.header h1,
-.brand {
-  font-size: 1.25rem;
-  font-weight: 600;
-}
-
-.brand > a {
-  color: var(--header-text);
-  text-decoration: none;
-}
-
-.brand svg {
-  vertical-align: middle;
-}
-
-.brand svg .np__bg {
-  fill: #fff;
-}
-
-.brand svg .np__txt {
-  fill: var(--brand-color);
-}
-
-.grid {
+.app-grid {
   display: grid;
   grid-template-areas:
     "markdown"
@@ -131,11 +33,11 @@ button:focus {
 
 #markdown,
 #html {
-  border-bottom: 1px solid var(--border-color);
+  border-bottom: 1px solid var(--grey100);
 }
 
 #markdown {
-  border-right: 1px solid var(--border-color);
+  border-right: 1px solid var(--grey100);
   grid-area: markdown;
   position: relative;
 }
@@ -210,7 +112,7 @@ button:focus {
 
 #preview-content table,
 #preview-content table th {
-  border-bottom: 1px solid #c5c5c5;
+  border-bottom: 1px solid var(--grey200);
 }
 
 #preview-content table td,
@@ -219,7 +121,7 @@ button:focus {
 }
 
 #preview-content table tbody tr:nth-child(2n) {
-  background-color: var(--bg-subtle);
+  background-color: var(--silver);
 }
 
 #preview-content ol,
@@ -228,12 +130,12 @@ button:focus {
 }
 
 #preview-content blockquote {
-  border-left: 1px solid var(--text-color);
+  border-left: 1px solid var(--black);
   padding-left: 0.5rem;
 }
 
 #preview-content code {
-  color: #e83e8c;
+  color: var(--pink);
   display: inline-block;
   font-family: monospace;
   font-size: 1rem;
@@ -242,13 +144,13 @@ button:focus {
 }
 
 #preview-content pre {
-  background-color: var(--bg-subtle);
+  background-color: var(--silver);
   padding: 0.5rem;
   width: 100%;
 }
 
 #preview-content pre code {
-  color: var(--text-color);
+  color: var(--black);
   font-size: 0.875rem;
 }
 
@@ -257,7 +159,7 @@ button:focus {
     font-size: 100%;
   }
 
-  .grid {
+  .app-grid {
     grid-template-areas:
       "markdown html"
       "preview preview";
@@ -291,43 +193,4 @@ button:focus {
   #markdown:hover::after {
     background-color: var(--handle-bg-hover);
   }
-}
-
-/* Utilities */
-.flex {
-  display: flex;
-  align-items: center;
-}
-
-.w-4 {
-  width: 1rem;
-}
-
-.ml-auto {
-  margin-left: auto;
-}
-
-.mr-2 {
-  margin-right: 0.5rem;
-}
-
-.icon {
-  display: inline-block;
-}
-
-/* https://a11yproject.com/posts/how-to-hide-content/ */
-.visually-hidden {
-  position: absolute !important;
-  height: 1px;
-  width: 1px;
-  overflow: hidden;
-  clip: rect(1px, 1px, 1px, 1px);
-}
-
-.visually-hidden a:focus,
-.visually-hidden input:focus,
-.visually-hidden button:focus {
-  position: static;
-  width: auto;
-  height: auto;
 }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -74,6 +74,9 @@ button:focus {
 }
 
 .header {
+  /* overrides AlbertCSS's grid-based .header layout, which this app's
+     header markup (no grid-area-assigned children) doesn't match */
+  display: block;
   background-color: var(--header-bg);
   border-bottom: 1px solid var(--header-border);
   color: var(--header-text);


### PR DESCRIPTION
## Summary

- `index.html` now loads AlbertCSS (`https://albertcss.craigmcn.com/css/albert.min.css`), matching `music-monday.html` and the site-wide standard of loading AlbertCSS via CDN link
- Removed CSS/HTML that duplicated styles AlbertCSS already provides (header/brand layout and typography, color tokens like `--silver`/`--grey100`/`--grey200`/`--black`/`--pink`, utility classes like `.flex`/`.ml-auto`/`.mr-2`/`.icon`/`.visually-hidden`) — `src/styles/index.css` now only contains the styles this app actually needs on top of AlbertCSS
- The brand ("craigmcn") header text now renders in AlbertCSS's Outfit font family, consistent between both pages of the app
- Renamed `<main class="grid">` to `<main class="app-grid">` (in `index.html`, `src/styles/index.css`, and the `querySelector` in `src/scripts/index.ts`). AlbertCSS ships its own `.grid` utility (a 12-column `display: grid; grid-template-columns: repeat(12, 1fr)`), and this app's `.grid` rule didn't declare `grid-template-columns` at the mobile breakpoint — so AlbertCSS's 12-column declaration was winning by default and squeezing the Markdown/HTML/Preview panels into a sliver of the viewport on mobile. Renaming sidesteps this collision (and any other AlbertCSS utility class of the same name) rather than adding another one-off override.

Closes #74

## Test plan

- [x] `yarn format:check`, `yarn lint`, `yarn tsc -b`, `yarn test:run`, `yarn build` all pass
- [x] Visually verified desktop (1280x800) and mobile (390x800) with Playwright screenshots before/after each change — brand font now consistent, mobile panels now span full width, desktop layout unchanged