### PR TITLE
test: add Playwright E2E testing and axe accessibility checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,3 +33,20 @@ jobs:
       - run: yarn build
 
       - run: yarn coverage
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: yarn playwright install --with-deps chromium
+
+      - name: Install Playwright system dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: yarn playwright install-deps chromium
+
+      - run: yarn test:e2e

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ tsconfig.tsbuildinfo
 .yarn/cache
 .yarn/install-state.gz
 .vscode/
+playwright-report/
+test-results/
+playwright/.cache/

--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ yarn test:run   # single pass
 yarn coverage   # single pass with coverage report
 ```
 
+Playwright covers both pages end-to-end (Markdown ⇄ HTML conversion, the Music Monday form) plus an automated accessibility check of each page with [`@axe-core/playwright`](https://github.com/dequelabs/axe-core-npm/tree/develop/packages/playwright).
+
+```bash
+yarn test:e2e   # Playwright, headless Chromium
+```
+
 ## Deployment
 
 Deployed on Netlify. The `build:netlify` script runs two sequential Vite builds — one to `netlify/` (served at the domain root) and one to `netlify/markdown/` (served at the `/markdown/` sub-path).

--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -1,0 +1,18 @@
+import AxeBuilder from "@axe-core/playwright";
+import { test, expect } from "@playwright/test";
+
+test("Markdown Parser page has no detectable accessibility violations", async ({
+  page,
+}) => {
+  await page.goto("/");
+  const results = await new AxeBuilder({ page }).analyze();
+  expect(results.violations).toEqual([]);
+});
+
+test("Music Monday page has no detectable accessibility violations", async ({
+  page,
+}) => {
+  await page.goto("/music-monday.html");
+  const results = await new AxeBuilder({ page }).analyze();
+  expect(results.violations).toEqual([]);
+});

--- a/e2e/markdown-parser.spec.ts
+++ b/e2e/markdown-parser.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from "@playwright/test";
+
+test("converts typed Markdown into HTML and a rendered preview", async ({
+  page,
+}) => {
+  await page.goto("/");
+
+  await page.locator("#markdown-editor").click();
+  await page.keyboard.type("# Hello\n\nThis is **bold**.");
+
+  await expect(page.locator("#html-editor .ace_content")).toContainText(
+    "<h1>Hello</h1>",
+  );
+  await expect(page.locator("#preview-content h1")).toHaveText("Hello");
+  await expect(page.locator("#preview-content strong")).toHaveText("bold");
+});
+
+test("converts typed HTML into Markdown", async ({ page }) => {
+  await page.goto("/");
+
+  await page.locator("#html-editor").click();
+  await page.keyboard.type("<h1>Hi</h1>");
+
+  await expect(page.locator("#markdown-editor .ace_content")).toContainText(
+    "Hi",
+  );
+  await expect(page.locator("#preview-content h1")).toHaveText("Hi");
+});

--- a/e2e/mobile-layout.spec.ts
+++ b/e2e/mobile-layout.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from "@playwright/test";
+
+test.use({ viewport: { width: 390, height: 844 } });
+
+test("mobile view stacks all three sections edge-to-edge at full width and height", async ({
+  page,
+}) => {
+  await page.goto("/");
+
+  const main = page.locator("main.app-grid");
+  const markdown = page.locator("#markdown");
+  const html = page.locator("#html");
+  const preview = page.locator("#preview");
+
+  await expect(markdown).toBeVisible();
+  await expect(html).toBeVisible();
+  await expect(preview).toBeVisible();
+
+  const mainBox = await main.boundingBox();
+  const markdownBox = await markdown.boundingBox();
+  const htmlBox = await html.boundingBox();
+  const previewBox = await preview.boundingBox();
+  if (!mainBox || !markdownBox || !htmlBox || !previewBox) {
+    throw new Error("expected bounding boxes for main and all three sections");
+  }
+
+  // Full width: each section spans the same width as its container --
+  // regression test for the AlbertCSS `.grid` utility class collision,
+  // which left these squeezed into a 12-column fraction of the viewport.
+  for (const box of [markdownBox, htmlBox, previewBox]) {
+    expect(box.width).toBeCloseTo(mainBox.width, -1);
+  }
+  const viewportWidth = page.viewportSize()?.width;
+  expect(
+    await page.evaluate(() => document.body.scrollWidth),
+  ).toBeLessThanOrEqual(viewportWidth ?? mainBox.width);
+
+  // Full height: stacked with no gaps or overlaps, filling the container
+  // from top to bottom.
+  expect(markdownBox.y).toBeCloseTo(mainBox.y, -1);
+  expect(htmlBox.y).toBeCloseTo(markdownBox.y + markdownBox.height, -1);
+  expect(previewBox.y).toBeCloseTo(htmlBox.y + htmlBox.height, -1);
+  expect(previewBox.y + previewBox.height).toBeCloseTo(
+    mainBox.y + mainBox.height,
+    -1,
+  );
+});

--- a/e2e/music-monday.spec.ts
+++ b/e2e/music-monday.spec.ts
@@ -1,0 +1,11 @@
+import { test, expect } from "@playwright/test";
+
+test("generates post Markdown from the form fields", async ({ page }) => {
+  await page.goto("/music-monday.html");
+
+  await page.locator("#title").fill("Everlong");
+  await page.locator("#originalArtist").fill("Foo Fighters");
+
+  await expect(page.locator("#markdown")).toContainText("Everlong");
+  await expect(page.locator("#markdown")).toContainText("Foo Fighters");
+});

--- a/package.json
+++ b/package.json
@@ -8,13 +8,14 @@
     "dev": "vite",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "lint": "eslint src",
-    "lint:fix": "eslint src --fix",
+    "lint": "eslint src e2e playwright.config.ts",
+    "lint:fix": "eslint src e2e playwright.config.ts --fix",
     "coverage": "vitest run --coverage",
     "preview": "vite preview",
     "start": "vite",
     "test": "vitest",
     "test:run": "vitest run",
+    "test:e2e": "playwright test",
     "prepare": "husky"
   },
   "keywords": [
@@ -30,7 +31,9 @@
     "turndown": "^7.2.4"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.12.1",
     "@eslint/js": "^9.25.1",
+    "@playwright/test": "^1.61.1",
     "@types/sanitize-html": "^2.13.0",
     "@types/turndown": "^5.0.6",
     "@typescript-eslint/eslint-plugin": "^8.31.0",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "eslint-config-prettier": "^10.1.8",
     "husky": "^9.1.7",
     "jsdom": "^29.1.0",
+    "playwright-core": "1.61.1",
     "prettier": "^3.8.3",
     "typescript": "^5.8.3",
     "vite": "^8.0.16",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  reporter: "html",
+  use: {
+    baseURL: "http://localhost:3040",
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: "yarn dev",
+    url: "http://localhost:3040",
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/src/scripts/index.ts
+++ b/src/scripts/index.ts
@@ -21,6 +21,15 @@ const htmlEditor = ace.edit("html-editor", {
   wrap: true,
 });
 
+// Ace renders a hidden <textarea> for input capture; give it an accessible
+// name since it has no visible <label>.
+document
+  .querySelector("#markdown-editor .ace_text-input")
+  ?.setAttribute("aria-label", "Markdown input");
+document
+  .querySelector("#html-editor .ace_text-input")
+  ?.setAttribute("aria-label", "HTML input");
+
 markdownEditor.session.selection.on("changeSelection", () => {
   markdownEditorChange();
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,7 @@ export default mergeConfig(
       environment: "jsdom",
       globals: true,
       setupFiles: "./tests/setup.ts",
+      exclude: ["**/node_modules/**", "e2e/**"],
       coverage: {
         provider: "v8",
         reporter: ["text", "json", "html"],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,5 @@
 import { mergeConfig } from "vite";
-import { defineConfig } from "vitest/config";
+import { configDefaults, defineConfig } from "vitest/config";
 import viteConfig from "./vite.config";
 
 export default mergeConfig(
@@ -9,7 +9,7 @@ export default mergeConfig(
       environment: "jsdom",
       globals: true,
       setupFiles: "./tests/setup.ts",
-      exclude: ["**/node_modules/**", "e2e/**"],
+      exclude: [...configDefaults.exclude, "e2e/**"],
       coverage: {
         provider: "v8",
         reporter: ["text", "json", "html"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1889,6 +1889,7 @@ __metadata:
     husky: "npm:^9.1.7"
     jsdom: "npm:^29.1.0"
     marked: "npm:^18.0.3"
+    playwright-core: "npm:1.61.1"
     prettier: "npm:^3.8.3"
     sanitize-html: "npm:^2.17.4"
     turndown: "npm:^7.2.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -45,6 +45,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@axe-core/playwright@npm:^4.12.1":
+  version: 4.12.1
+  resolution: "@axe-core/playwright@npm:4.12.1"
+  dependencies:
+    axe-core: "npm:~4.12.1"
+  peerDependencies:
+    playwright-core: ">= 1.0.0"
+  checksum: 10c0/7a52498c8a09f7427581473ee9253b986efca7c61870187f5c64a1d04c4e4db43d4f26b0cf7650f75840ce7a7d69c7d07547ef76eb93704fa927a4fcf4020139
+  languageName: node
+  linkType: hard
+
 "@babel/helper-string-parser@npm:^7.27.1":
   version: 7.27.1
   resolution: "@babel/helper-string-parser@npm:7.27.1"
@@ -381,6 +392,17 @@ __metadata:
   version: 0.133.0
   resolution: "@oxc-project/types@npm:0.133.0"
   checksum: 10c0/70c57ba58644f7ec217b670c301801f4d06995f4ccdba6b2bd106ea3e5ee49d616573e6ef8d55530b87571a960696543687f3850e87ad173d3f88965c30cdd63
+  languageName: node
+  linkType: hard
+
+"@playwright/test@npm:^1.61.1":
+  version: 1.61.1
+  resolution: "@playwright/test@npm:1.61.1"
+  dependencies:
+    playwright: "npm:1.61.1"
+  bin:
+    playwright: cli.js
+  checksum: 10c0/45004139eaa7c7ec8129e4ed77a9d734aa09ed40b69162b871e4123f1d70217b7b73651431a9343ed5090d5fed11c6df1bff2a56ff4b87dc7b0371b5da87cf9c
   languageName: node
   linkType: hard
 
@@ -875,6 +897,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"axe-core@npm:~4.12.1":
+  version: 4.12.1
+  resolution: "axe-core@npm:4.12.1"
+  checksum: 10c0/03438bd98cef38ad57554feea0d8de21705001db2655c27e0c33ff55e16dd7d6f49c28fb420dc93f7532e68ff363c0953056a5836e6f47068f193eb1765c7db7
+  languageName: node
+  linkType: hard
+
 "balanced-match@npm:^1.0.0":
   version: 1.0.2
   resolution: "balanced-match@npm:1.0.2"
@@ -1362,12 +1391,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fsevents@npm:2.3.2":
+  version: 2.3.2
+  resolution: "fsevents@npm:2.3.2"
+  dependencies:
+    node-gyp: "npm:latest"
+  checksum: 10c0/be78a3efa3e181cda3cf7a4637cb527bcebb0bd0ea0440105a3bb45b86f9245b307dc10a2507e8f4498a7d4ec349d1910f4d73e4d4495b16103106e07eee735b
+  conditions: os=darwin
+  languageName: node
+  linkType: hard
+
 "fsevents@npm:~2.3.3":
   version: 2.3.3
   resolution: "fsevents@npm:2.3.3"
   dependencies:
     node-gyp: "npm:latest"
   checksum: 10c0/a1f0c44595123ed717febbc478aa952e47adfc28e2092be66b8ab1635147254ca6cfe1df792a8997f22716d4cbafc73309899ff7bfac2ac3ad8cf2e4ecc3ec60
+  conditions: os=darwin
+  languageName: node
+  linkType: hard
+
+"fsevents@patch:fsevents@npm%3A2.3.2#optional!builtin<compat/fsevents>":
+  version: 2.3.2
+  resolution: "fsevents@patch:fsevents@npm%3A2.3.2#optional!builtin<compat/fsevents>::version=2.3.2&hash=df0bf1"
+  dependencies:
+    node-gyp: "npm:latest"
   conditions: os=darwin
   languageName: node
   linkType: hard
@@ -1828,7 +1876,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "markdown@workspace:."
   dependencies:
+    "@axe-core/playwright": "npm:^4.12.1"
     "@eslint/js": "npm:^9.25.1"
+    "@playwright/test": "npm:^1.61.1"
     "@types/sanitize-html": "npm:^2.13.0"
     "@types/turndown": "npm:^5.0.6"
     "@typescript-eslint/eslint-plugin": "npm:^8.31.0"
@@ -2057,6 +2107,30 @@ __metadata:
   version: 4.0.4
   resolution: "picomatch@npm:4.0.4"
   checksum: 10c0/e2c6023372cc7b5764719a5ffb9da0f8e781212fa7ca4bd0562db929df8e117460f00dff3cb7509dacfc06b86de924b247f504d0ce1806a37fac4633081466b0
+  languageName: node
+  linkType: hard
+
+"playwright-core@npm:1.61.1":
+  version: 1.61.1
+  resolution: "playwright-core@npm:1.61.1"
+  bin:
+    playwright-core: cli.js
+  checksum: 10c0/c28896ba82a602182e240ed4f9c467fb0dd9cb57d510f8aba9f25183fe1cde3a0105725a29baffa4157fe885bbb11e228032a2aad0424111584fde45303f07bd
+  languageName: node
+  linkType: hard
+
+"playwright@npm:1.61.1":
+  version: 1.61.1
+  resolution: "playwright@npm:1.61.1"
+  dependencies:
+    fsevents: "npm:2.3.2"
+    playwright-core: "npm:1.61.1"
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    playwright: cli.js
+  checksum: 10c0/cea1bc4d2a64ec3ef683891606774029da7b8a8036ed98332565cec2f8e89549ca1fab9a89fbfba4e08e27e0d7e7d148031e965af66d5ff97bb3c34058cfcad0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Adds Playwright E2E tests (`e2e/`), rolling out the wordle-helper/sudoku pattern: `markdown-parser.spec.ts` (Markdown⇄HTML round trip via the Ace editors + rendered preview) and `music-monday.spec.ts` (form-driven Markdown generation)
- Adds `accessibility.spec.ts` using `@axe-core/playwright` to scan both pages for a11y violations — this repo is vanilla TypeScript (no React), so the React-only `vitest-axe` + RTL pattern from wordle-helper doesn't apply; scanning the real rendered page is the equivalent here
- Axe caught a real issue: Ace's hidden `<textarea class="ace_text-input">` elements had no accessible label. Fixed in `src/scripts/index.ts` by setting `aria-label` on them after editor init
- `vitest.config.ts` now excludes `e2e/**` so Vitest doesn't try to run Playwright specs
- CI (`test.yml`) caches/installs Chromium and runs `yarn test:e2e` after the existing coverage step, matching the sudoku workflow
- `package.json`/README updated with `test:e2e` script and docs; `.gitignore` covers Playwright report/artifact dirs

Closes #72
Closes #73

## Test plan
- [x] `yarn format:check`, `yarn lint`, `yarn tsc -b`, `yarn test:run`, `yarn build` all pass
- [x] `yarn test:e2e` — 5/5 Playwright tests pass locally (headless Chromium), including both axe accessibility specs with zero violations