### PR TITLE
chore: bump undici to 7.28.0 (Dependabot alerts)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 9
+  version: 10
   cacheKey: 10c0
 
 "@asamuzakjp/css-color@npm:^5.1.11":
@@ -2511,9 +2511,9 @@ __metadata:
   linkType: hard
 
 "undici@npm:^7.25.0":
-  version: 7.25.0
-  resolution: "undici@npm:7.25.0"
-  checksum: 10c0/02a0b45dc14eb91bc488948750232450fe52f27a6b08086d6ac6736bb47908d600fe3a96d346f12eab24729c782e5c2f693bc8e8eca6696d4e4c09b1ed4cb4ec
+  version: 7.28.0
+  resolution: "undici@npm:7.28.0"
+  checksum: 10c0/fe781983a26098795e99bb1f64906cbb7d0bcaa029a26baade007b53ea67f2631d189b8f9671a31f4c8d0cb3773b7559608628ba54452fef51fec90e7c78bb0d
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 10
+  version: 9
   cacheKey: 10c0
 
 "@asamuzakjp/css-color@npm:^5.1.11":


### PR DESCRIPTION
## Summary
- Bumps the transitive `undici` resolution (pulled in via `jsdom@^29.1.0` → `undici@^7.25.0`) from 7.25.0 to 7.28.0
- Resolves all 6 open Dependabot alerts (#100–#103, #105, #106): SOCKS5 proxy cross-origin routing, TLS certificate validation bypass, cache poisoning, header injection, response queue poisoning, and cookie SameSite downgrade
- No `package.json` change needed — `^7.25.0` already permits 7.28.0, this is a lockfile-only resolution bump

## Test plan
- [x] `yarn format:check`
- [x] `yarn lint`
- [x] `yarn tsc -b`
- [x] `yarn test:run` (35 tests passing)
- [x] `yarn build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)