### PR TITLE
Add vertical resize handle for mobile stacked layout

### DIFF
--- a/e2e/resize-handle.spec.ts
+++ b/e2e/resize-handle.spec.ts
@@ -1,0 +1,112 @@
+import { test, expect } from "@playwright/test";
+
+// Regression tests for the Markdown/HTML resize handle: it must sit on the
+// right edge of #markdown at desktop widths (horizontal drag) and on the
+// bottom edge of #markdown at mobile widths, once the sections stack
+// (vertical drag).
+
+test("desktop: the handle is rendered on the right edge of #markdown", async ({
+  page,
+}) => {
+  await page.goto("/");
+
+  const handleStyle = await page.evaluate(() => {
+    const style = getComputedStyle(
+      document.getElementById("markdown")!,
+      "::after",
+    );
+    return { left: style.left, right: style.right, cursor: style.cursor };
+  });
+
+  // `right: 0` must actually win — if a leftover `left: 0` from the mobile
+  // rule is still in effect, the CSS box-offset resolution rules make
+  // `right`'s used value something other than 0, even though it was
+  // authored as `right: 0`.
+  expect(handleStyle.right).toBe("0px");
+  expect(handleStyle.left).not.toBe("0px");
+  expect(handleStyle.cursor).toBe("ew-resize");
+});
+
+test("desktop: dragging the right edge of #markdown resizes it horizontally", async ({
+  page,
+}) => {
+  await page.goto("/");
+
+  const markdown = page.locator("#markdown");
+  const html = page.locator("#html");
+
+  const markdownBefore = await markdown.boundingBox();
+  const htmlBefore = await html.boundingBox();
+  if (!markdownBefore || !htmlBefore) {
+    throw new Error("expected bounding boxes for #markdown and #html");
+  }
+
+  const dragY = markdownBefore.y + markdownBefore.height / 2;
+  await page.mouse.move(markdownBefore.x + markdownBefore.width - 1, dragY);
+  await page.mouse.down();
+  await page.mouse.move(markdownBefore.x + markdownBefore.width + 100, dragY);
+  await page.mouse.up();
+
+  const markdownAfter = await markdown.boundingBox();
+  const htmlAfter = await html.boundingBox();
+  if (!markdownAfter || !htmlAfter) {
+    throw new Error("expected bounding boxes for #markdown and #html");
+  }
+
+  expect(markdownAfter.width).toBeGreaterThan(markdownBefore.width + 50);
+  expect(htmlAfter.width).toBeLessThan(htmlBefore.width - 50);
+  // Dragging the right edge must not affect vertical layout.
+  expect(markdownAfter.height).toBeCloseTo(markdownBefore.height, -1);
+});
+
+test("mobile: the handle is rendered on the bottom edge of #markdown", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto("/");
+
+  const handleStyle = await page.evaluate(() => {
+    const style = getComputedStyle(
+      document.getElementById("markdown")!,
+      "::after",
+    );
+    return { top: style.top, bottom: style.bottom, cursor: style.cursor };
+  });
+
+  expect(handleStyle.bottom).toBe("0px");
+  expect(handleStyle.top).not.toBe("0px");
+  expect(handleStyle.cursor).toBe("ns-resize");
+});
+
+test("mobile: dragging the bottom edge of #markdown resizes it vertically", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto("/");
+
+  const markdown = page.locator("#markdown");
+  const html = page.locator("#html");
+
+  const markdownBefore = await markdown.boundingBox();
+  const htmlBefore = await html.boundingBox();
+  if (!markdownBefore || !htmlBefore) {
+    throw new Error("expected bounding boxes for #markdown and #html");
+  }
+
+  const dragX = markdownBefore.x + markdownBefore.width / 2;
+  await page.mouse.move(dragX, markdownBefore.y + markdownBefore.height - 1);
+  await page.mouse.down();
+  await page.mouse.move(dragX, markdownBefore.y + markdownBefore.height + 80);
+  await page.mouse.up();
+
+  const markdownAfter = await markdown.boundingBox();
+  const htmlAfter = await html.boundingBox();
+  if (!markdownAfter || !htmlAfter) {
+    throw new Error("expected bounding boxes for #markdown and #html");
+  }
+
+  expect(markdownAfter.height).toBeGreaterThan(markdownBefore.height + 40);
+  expect(htmlAfter.height).toBeLessThan(htmlBefore.height);
+  // Dragging the bottom edge must not affect horizontal layout.
+  expect(markdownAfter.width).toBeCloseTo(markdownBefore.width, -1);
+});

--- a/src/scripts/index.ts
+++ b/src/scripts/index.ts
@@ -70,6 +70,8 @@ let previewTop: number | undefined;
 let touchDiff: number | undefined;
 let columnX: number | undefined;
 let columnTouchDiff: number | undefined;
+let rowY: number | undefined;
+let rowTouchDiff: number | undefined;
 const HANDLE_SIZE = 4; // must match --handle-size in index.css
 
 const setPreviewHeight = (e: Event) => {
@@ -132,6 +134,37 @@ const setColumnWidths = (e: Event) => {
   htmlEditor.resize();
 };
 
+const setMarkdownHeight = (e: Event) => {
+  if (e.type === "mousemove") rowY = (e as MouseEvent).clientY;
+  if (e.type === "touchmove")
+    rowY = (e as TouchEvent).touches[0].clientY - (rowTouchDiff ?? 0);
+
+  if (rowY !== undefined) {
+    const mainRect = main.getBoundingClientRect();
+    const totalHeight = mainRect.height;
+    const newHeight = rowY - mainRect.top;
+    const minHeight = totalHeight * 0.2;
+    const maxHeight = totalHeight * 0.8;
+    const setHeight =
+      newHeight > maxHeight
+        ? maxHeight
+        : newHeight < minHeight
+          ? minHeight
+          : newHeight;
+
+    if (setHeight !== newHeight) {
+      rowY = mainRect.top + setHeight;
+    }
+
+    const previewRowHeight =
+      getComputedStyle(main).gridTemplateRows.split(" ")[2];
+    main.style.gridTemplateRows = `${setHeight}px auto ${previewRowHeight}`;
+  }
+
+  markdownEditor.resize();
+  htmlEditor.resize();
+};
+
 const startDragging = () => {
   document.body.style.userSelect = "none";
 };
@@ -140,8 +173,10 @@ const stopDragging = () => {
   document.body.style.userSelect = "";
   document.removeEventListener("mousemove", setPreviewHeight, false);
   document.removeEventListener("mousemove", setColumnWidths, false);
+  document.removeEventListener("mousemove", setMarkdownHeight, false);
   document.removeEventListener("touchmove", setPreviewHeight, false);
   document.removeEventListener("touchmove", setColumnWidths, false);
+  document.removeEventListener("touchmove", setMarkdownHeight, false);
 };
 
 preview.querySelector(".subheader")?.addEventListener(
@@ -178,13 +213,20 @@ markdown.addEventListener(
   (e: Event) => {
     const numAreas =
       getComputedStyle(main).gridTemplateAreas.split('" ').length;
+    const mouseEvent = e as MouseEvent;
+    const markdownRect = markdown.getBoundingClientRect();
     if (
       numAreas === 2 &&
-      (e as MouseEvent).clientX >=
-        markdown.getBoundingClientRect().right - HANDLE_SIZE
+      mouseEvent.clientX >= markdownRect.right - HANDLE_SIZE
     ) {
       startDragging();
       document.addEventListener("mousemove", setColumnWidths, false);
+    } else if (
+      numAreas === 3 &&
+      mouseEvent.clientY >= markdownRect.bottom - HANDLE_SIZE
+    ) {
+      startDragging();
+      document.addEventListener("mousemove", setMarkdownHeight, false);
     }
   },
   false,
@@ -195,13 +237,19 @@ markdown.addEventListener(
   (e: Event) => {
     const numAreas =
       getComputedStyle(main).gridTemplateAreas.split('" ').length;
-    if (numAreas !== 2) return;
     const touch = (e as TouchEvent).touches[0];
     const markdownRect = markdown.getBoundingClientRect();
-    if (touch.clientX >= markdownRect.right - HANDLE_SIZE) {
+    if (numAreas === 2 && touch.clientX >= markdownRect.right - HANDLE_SIZE) {
       columnTouchDiff = touch.clientX - markdownRect.right;
       startDragging();
       document.addEventListener("touchmove", setColumnWidths, false);
+    } else if (
+      numAreas === 3 &&
+      touch.clientY >= markdownRect.bottom - HANDLE_SIZE
+    ) {
+      rowTouchDiff = touch.clientY - markdownRect.bottom;
+      startDragging();
+      document.addEventListener("touchmove", setMarkdownHeight, false);
     }
   },
   false,
@@ -217,6 +265,8 @@ window.addEventListener(
     if (numAreas !== 2) {
       main.style.gridTemplateColumns = "";
       columnX = undefined;
+    } else {
+      rowY = undefined;
     }
   },
   false,

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -50,6 +50,8 @@ body {
   height: var(--handle-size);
   left: 0;
   position: absolute;
+  right: auto;
+  top: auto;
   width: 100%;
   z-index: 10;
 }
@@ -196,9 +198,11 @@ body {
 
   #markdown::after {
     background-color: var(--handle-bg);
+    bottom: auto;
     content: "";
     cursor: ew-resize;
     height: 100%;
+    left: auto;
     position: absolute;
     right: 0;
     top: 0;

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -42,6 +42,22 @@ body {
   position: relative;
 }
 
+#markdown::after {
+  background-color: var(--handle-bg);
+  bottom: 0;
+  content: "";
+  cursor: ns-resize;
+  height: var(--handle-size);
+  left: 0;
+  position: absolute;
+  width: 100%;
+  z-index: 10;
+}
+
+#markdown:hover::after {
+  background-color: var(--handle-bg-hover);
+}
+
 #html {
   grid-area: html;
 }


### PR DESCRIPTION
## Summary
- The Markdown/HTML resize handle only supported horizontal dragging and was gated to the desktop two-column layout (`numAreas === 2`), so it disappeared entirely on mobile where the panels stack vertically.
- Adds a matching vertical (`ns-resize`) handle at the bottom edge of the Markdown panel for the mobile stacked layout (`numAreas === 3`), with mouse and touch drag support, mirroring the existing horizontal handle and the Preview panel's own vertical handle.

Closes #85

## Test plan
- [x] `yarn format:check`
- [x] `yarn lint`
- [x] `yarn tsc -b`
- [x] `yarn test:run` (35 tests passing)
- [x] `yarn build`
- [ ] Manual check on a mobile viewport: drag the handle below the Markdown panel and confirm Markdown/HTML panels resize while Preview height is unaffected