### PR TITLE
Bump brace-expansion to 5.0.8 (Dependabot alert)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -938,11 +938,11 @@ __metadata:
   linkType: hard
 
 "brace-expansion@npm:^5.0.5":
-  version: 5.0.5
-  resolution: "brace-expansion@npm:5.0.5"
+  version: 5.0.8
+  resolution: "brace-expansion@npm:5.0.8"
   dependencies:
     balanced-match: "npm:^4.0.2"
-  checksum: 10c0/4d238e14ed4f5cc9c07285550a41cef23121ca08ba99fa9eb5b55b580dcb6bf868b8210aa10526bdc9f8dc97f33ca2a7259039c4cc131a93042beddb424c48e3
+  checksum: 10c0/73304caafd00fdc5b0168e693ac15bf25b6357dec76d1195fcd628fe2cf99c46f9c889a7ecfa3cfe236dbd2d5ce3e27a6ccc4370b46d475d0d19081e11f86019
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Bumps the transitive `brace-expansion` dependency from 5.0.5 to 5.0.8, resolving [Dependabot alert #107](https://github.com/craigmcn/markdown/security/dependabot/107) (ReDoS via exponential-time expansion, vulnerable range `>=3.0.0 <5.0.7`).
- Pulled in via `@typescript-eslint/typescript-estree` → `minimatch@10` (dev-only tooling, not part of the shipped app bundle).
- `yarn up -R brace-expansion` — 5.0.8 satisfies the existing `^5.0.5` range, so no other dependency changes were needed.

## Test plan
- [x] `yarn format:check`
- [x] `yarn lint`
- [x] `yarn tsc -b`
- [x] `yarn test:run` (23 tests passing)
- [x] `yarn build`