### PR TITLE
chore: pin undici to 7.29.0 (Dependabot alerts #116-120)

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,5 +53,8 @@
     "type": "git",
     "url": "https://github.com/craigmcn/markdown.git"
   },
+  "resolutions": {
+    "undici@npm:^7.25.0": "^7.29.0"
+  },
   "packageManager": "yarn@4.14.1+sha512.64df448055b2d37ba269d7db535a469b8da93f8ef1140c25fd7a83c00a8fbaacb214ca0e02553b92a2c54cef78bb67d0b4817fab02001df0e24fac0faccc3b42"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2490,10 +2490,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:^7.25.0":
-  version: 7.28.0
-  resolution: "undici@npm:7.28.0"
-  checksum: 10c0/fe781983a26098795e99bb1f64906cbb7d0bcaa029a26baade007b53ea67f2631d189b8f9671a31f4c8d0cb3773b7559608628ba54452fef51fec90e7c78bb0d
+"undici@npm:^7.29.0":
+  version: 7.29.0
+  resolution: "undici@npm:7.29.0"
+  checksum: 10c0/85ea96e91e7f3de24de678cbbc54230fdd641a3b0643005f2aef044af1f1a2db8fbecb88b28e6fa78bb41ffeafda4479b57075b6b6ab92beac4b7b5ab53f9b10
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Fixes Dependabot alerts #116-120: `undici` transitive dependency via `jsdom` (^7.25.0 → resolved 7.28.0) was vulnerable to several CVEs fixed in 7.29.0 (cache directive parsing crash/info disclosure, response desync via retry interceptor, cookie attribute injection, CRLF injection)
- Added a `resolutions` entry scoped to jsdom's exact requested range (`undici@npm:^7.25.0`) to force the patched version, since jsdom has not yet released a version pulling in fixed undici

## Test plan
- [x] `yarn why undici` confirms no resolved copy remains in the vulnerable range
- [x] `yarn format:check` passes
- [x] `yarn lint` passes
- [x] `yarn build` passes
- [x] `yarn test:run` passes (23/23)